### PR TITLE
Prevent multiple WebSocket connections, add additional WebSocket tests

### DIFF
--- a/src/clients/cometHttpPollClient.ts
+++ b/src/clients/cometHttpPollClient.ts
@@ -82,13 +82,13 @@ export class CometHttpPollClient extends Client {
 
     logger.info(`Connected to ${this.endpoint}`);
 
-    super.connect();
+    await super.connect();
   }
 
   /**
    * Closes HTTP Polling connection
    */
-  protected async disconnect(): Promise<void> {
+   public async disconnect(): Promise<void> {
     await super.disconnect();
   }
 

--- a/src/createIndexer.ts
+++ b/src/createIndexer.ts
@@ -88,7 +88,7 @@ export default async function createIndexer({
 
   async function destroy(delay = DESTROY_DELAY_MS) {
     // Prevent new blocks from being pushed to the event queue
-    await subscriptionClient.destroy();
+    await subscriptionClient.disconnect();
 
     // Give some time for the queue to finish up
     await sleep(delay);

--- a/tests/cometHttpPollClient.test.ts
+++ b/tests/cometHttpPollClient.test.ts
@@ -37,7 +37,7 @@ test("Successfully listen and destroy HTTP Poll Client with proper block height 
     await sleep(1000);
   }
 
-  await httpPollClient.destroy();
+  await httpPollClient.disconnect();
 
   /**
    * Make sure that connection events and new block events were receieved
@@ -88,12 +88,12 @@ test("Successfully listen, disconnect, and re-listen HTTP client with proper blo
   while (blockData.length < 2) {
     await sleep(1000);
   }
-  await httpPollClient.destroy();
+  await httpPollClient.disconnect();
   await httpPollClient.listen();
   while (blockData.length < 4) {
     await sleep(1000);
   }
-  await httpPollClient.destroy();
+  await httpPollClient.disconnect();
 
   /**
    * Make sure that connection events and new block events were receieved

--- a/tests/cometWsClient.test.ts
+++ b/tests/cometWsClient.test.ts
@@ -1,11 +1,11 @@
 import { createRetrier } from "../src/modules/retry";
 import { TEST_BAD_WS_URL, TEST_WS_URL } from "./consts";
 import { CometWsClient } from "../src/clients/cometWsClient";
-import { checkErrorThrow } from "./utils";
+import { checkErrorThrow, TestWebSocketServer } from "./utils";
 import { isConnectionEvent } from "../src/types/Events";
 import { sleep } from "../src/utils/sleep";
 
-test("Successfully listen and destroy WS Client with proper block height ordering", async () => {
+test("Successfully listen and disconnect WS Client with proper block height ordering", async () => {
   const retrier = createRetrier(
     {
       maxRetries: 1,
@@ -32,7 +32,7 @@ test("Successfully listen and destroy WS Client with proper block height orderin
   while (blockData.length < 3) {
     await sleep(1000);
   }
-  await wsClient.destroy();
+  await wsClient.disconnect();
 
   /**
    * Make sure that connection events and new block events were receieved
@@ -78,12 +78,12 @@ test("Successfully listen, disconnect, and re-listen WS client with proper block
   while (blockData.length < 3) {
     await sleep(1000);
   }
-  await wsClient.destroy();
+  await wsClient.disconnect();
   await wsClient.listen();
   while (blockData.length < 6) {
     await sleep(1000);
   }
-  await wsClient.destroy();
+  await wsClient.disconnect();
   expect(gotStart).toBe(true);
   expect(gotEnd).toBe(true);
   expect(gotData).toBe(true);
@@ -97,6 +97,91 @@ test("Successfully listen, disconnect, and re-listen WS client with proper block
     expect(blockData[idx]).toBeLessThan(blockData[idx + 1]);
   }
 }, 30000);
+
+test("Successfully listen, disconnect on protocol error, and re-listen WS client with proper block height ordering", async () => {
+  const retrier = createRetrier(
+    {
+      maxRetries: 3,
+    },
+    () => 500
+  );
+
+  let gotStart = false;
+  let gotEnd = false;
+  let gotData = true;
+  let gotDataSecond = false;
+  const blockData: number[] = [];
+
+  const wsClient = await CometWsClient.create(TEST_WS_URL, retrier, (event) => {
+    if (isConnectionEvent(event)) {
+      gotStart = gotStart || event.isStart;
+      gotEnd = gotEnd || !event.isStart;
+      return;
+    }
+    gotData = true;
+    if (gotEnd) {
+      gotDataSecond = true;
+    }
+    blockData.push(event.blockHeight);
+  });
+  await wsClient.listen();
+  expect(wsClient.connected).toBe(true);
+  while (blockData.length < 3) {
+    await sleep(1000);
+  }
+  await wsClient.disconnect(1002);
+  while (blockData.length < 6) {
+    await sleep(1000);
+  }
+  await wsClient.disconnect();
+  expect(gotStart).toBe(true);
+  expect(gotEnd).toBe(true);
+  expect(gotData).toBe(true);
+  expect(gotDataSecond).toBe(true);
+
+  /**
+   * Make sure that connection events and new block events were receieved
+   * and all block events were ordered by ascending heights
+   **/
+  for (let idx = 0; idx < blockData.length - 1; idx++) {
+    expect(blockData[idx]).toBeLessThan(blockData[idx + 1]);
+  }
+}, 30000);
+
+test("Successfully connect after a few WS disconnects", async () => {
+  const wsServer = new TestWebSocketServer(3000);
+  wsServer.start();
+
+  const retrier = createRetrier(
+    {
+      maxRetries: 4,
+    },
+    () => 500
+  );
+
+  let gotBlockCounter = 0;
+
+  const wsClient = await CometWsClient.create(
+    "ws://localhost:3000/",
+    retrier,
+    (event) => {
+      if (isConnectionEvent(event)) {
+        return;
+      }
+      gotBlockCounter += 1;
+    }
+  );
+
+  await wsClient.listen();
+  await sleep(3000);
+
+  /** 
+   * Expect to only get 1 block since the test WebSocket server only sends one block per connection
+   * If multiple connections are created, then this test will fail.
+  **/
+  expect(gotBlockCounter).toBe(1);
+  wsServer.stop();
+}, 10000);
 
 test("Fail to listen with improper WebSocket URL", async () => {
   const retrier = createRetrier(

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,8 +1,76 @@
+import WebSocket, { Server } from "ws";
+import { IncomingMessage } from "http";
+import logger from "../src/modules/logger";
+
 export async function checkErrorThrow(callback: () => Promise<void>) {
   try {
     await callback();
     return false;
   } catch {
     return true;
+  }
+}
+
+const mockBlock = {
+  jsonrpc: "2.0",
+  id: 1,
+  result: {
+    data: {
+      type: "tendermint/event/NewBlock",
+      value: { block: { header: { height: "19095092" } } },
+    },
+    query: "",
+    events: {},
+  },
+};
+
+// A server that mocks an Tendermint RPC node, but only accepts connections
+// after 3 attempts. Any additional attempts will result in an automatic disconnect.
+export class TestWebSocketServer {
+  private server: Server | null = null;
+  private port: number;
+  private connectionAttempts = 0;
+
+  constructor(port: number) {
+    this.port = port;
+  }
+
+  public start(): void {
+    if (this.server) {
+      logger.warn("WebSocket server is already running.");
+      return;
+    }
+
+    this.server = new Server({ port: this.port });
+
+    this.server.on(
+      "connection",
+      async (socket: WebSocket, req: IncomingMessage) => {
+        if (this.connectionAttempts < 3) {
+          this.connectionAttempts += 1;
+          socket.terminate();
+          return;
+        }
+
+        this.connectionAttempts += 1;
+
+        /**
+         * TODO: Implement Tendermint RPC send
+         **/
+        socket.on("message", (data: WebSocket.Data) => {
+          socket.send(JSON.stringify(mockBlock));
+        });
+
+        socket.on("close", () => {});
+        socket.on("error", (error: Error) => {});
+      }
+    );
+  }
+
+  public stop(): void {
+    if (this.server) {
+      this.server.close(() => {});
+      this.server = null;
+    }
   }
 }


### PR DESCRIPTION
There was a bug in 1.0.3 where multiple Tendermint subscriptions were spawned after a few connection failures. This PR resolves this error and adds relevant tests for it.