### PR TITLE
Make retrier and persister optional, add more documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The backfiller will process blocks in descending order from largest block height
 1. Gets notified of new blocks through the `WebSocket` or `HTTP Polling` connection.
 2. Adds blocks in increasing order of block height to a queue.
 3. Processes each block from the queue and passes subscribed block, transaction, or event data to each `Indexer`.
-4. After all block data for a specific height is passed to an `Indexer`, inform the `Indexer`'s `Persister`, which is a single source of truth on which blocks have been indexed.
+4. After all block data for a specific height is passed to an `Indexer`, inform the `Indexer`'s `Persister` (if it exists), which is a single source of truth on which blocks have been indexed.
 5. In case of network failure or errors, employ the `Retrier` to retry indexing.
 
 This guarantees that `tendermint-indexer` achieves **exactly-once semantics**, can **recover** from network failure, and delivers block data in **increasing order** of block height.

--- a/README.md
+++ b/README.md
@@ -14,92 +14,50 @@ Then, setup a basic indexer and start running it!
 
 ```typescript
 // index.ts
-import { type BlockRange, Persister, Indexer, type Subscription, createIndexer, createExpBackoffRetrier, EndpointType, IndexerDataType, type EventIndexer, type BlockIndexer } from "tendermint-indexer";
-
-class BasicPersister implements Persister {
-  public async getUnprocessedBlockRanges(): Promise<BlockRange[]> {
-    // TODO: Return all recorded block heights from the database
-    return [{startBlockHeight: 1, endBlockHeight: 100}]
-  }
-
-  public async persistBlock(blockHeight: number): Promise<void> {
-    // TODO: Record blockHeight as being indexed in a database
-  }
-}
+import {
+  Indexer,
+  type Subscription,
+  createIndexer,
+  EndpointType,
+  IndexerDataType,
+  type EventIndexer,
+} from "tendermint-indexer";
 
 class BasicIndexer implements Indexer {
-persister: BasicPersister;
-
-  constructor() {
-    this.persister = new BasicPersister();
-  }
-
-  private async indexer1({
+  private async indexer({
     blockHeight,
     eventAttributes,
     eventType,
-  } : EventIndexer) {
-    // TODO: Replace with your own indexing logic!
+  }: EventIndexer) {
+    // Replace with your own indexing logic!
     console.log(blockHeight);
     console.log(eventAttributes);
     console.log(eventType);
   }
 
-  private async indexer2({
-    block,
-    blockHeight,
-    blockResults,
-  } : BlockIndexer) {
-    console.log(block);
-    console.log(blockHeight);
-    console.log(blockResults)
-  }
-
   public subscriptions(): Subscription[] {
     return [
       {
-        filter: {
-          eventType: {
-            matches: [
-              "transfer",
-              "mint",
-            ],
-            contains: [
-              "wasm-unstake"
-            ]
-          },
-        },
-        indexer: this.indexer1.bind(this),
+        indexer: this.indexer.bind(this),
         type: IndexerDataType.EVENT,
       },
-      {
-        indexer: this.indexer2.bind(this),
-        type: IndexerDataType.BLOCK,
-      }
     ];
   }
 
-  public async destroy(): Promise<void> {
-    // TODO: handle destroy logic
-  }
+  public async destroy(): Promise<void> {}
 }
-
-const retrier = createExpBackoffRetrier({
-  initialInterval: 1000,
-  expFactor: 2,
-  maxInterval: 60000,
-  jitter: 1000,
-});
 
 const indexer = await createIndexer({
   harness: {
     indexers: [new BasicIndexer()],
-    retrier,
     type: EndpointType.WEBSOCKET,
-    wsUrl: "wss://test-rpc-kujira.mintthemoon.xyz/websocket", // TODO: Replace with your RPC node websocket url
-    httpUrl: "https://test-rpc-kujira.mintthemoon.xyz", // TODO: Replace with your RPC HTTP node url
+    // Replace with your RPC node websocket url
+    wsUrl: "wss://test-rpc-kujira.mintthemoon.xyz/websocket",
+    // Replace with your RPC HTTP node url
+    httpUrl: "https://test-rpc-kujira.mintthemoon.xyz",
   },
-  minLogLevel: "trace", // See pino log levels (https://github.com/pinojs/pino/blob/main/docs/api.md#levels) for more options
+  // See pino log levels (https://github.com/pinojs/pino/blob/main/docs/api.md#levels) for more options
+  minLogLevel: "trace",
 });
 
 // Start the indexer
@@ -108,7 +66,7 @@ await indexer.start();
 // Get the indexer status
 console.log(
   "Is Websocket connection alive:",
-  indexer.isSubscriptionClientConnected(),
+  indexer.isSubscriptionClientConnected()
 );
 
 // Destroy the indexer
@@ -139,7 +97,134 @@ const backfiller = await createBackfiller({
 await backfiller.start();
 ```
 
-The backfiller will process blocks in descending order from largest block height or smallest block height, in an unordered, parallelized manner, or process blocks specified by block height.
+The backfiller will process blocks in descending order from largest block height or smallest block height, in an unordered, concurrent manner, or process blocks specified by block height.
+
+## Setup a Retrier
+
+A retrier wraps around network calls and connections and retries them on failure. It can also be triggered manually through code. By default, an exponential backoff retrier is used for indexing and backfilling. To specify a custom retrier:
+
+```typescript
+import { createRetrier, createExpBackoffRetrier } from "tendermint-indexer";
+
+// Basic retrier that retries 3 times, each with a 500 ms delay
+const retrier = createRetrier(
+  {
+    maxRetries: 3,
+  },
+  () => 500
+);
+
+// An exponential backoff retrier
+const expRetrier = createExpBackoffRetrier({
+  initialInterval: 1000,
+  expFactor: 2,
+  jitter: 1000,
+  maxRetries: 3,
+});
+
+const indexerWithCustomRetrier = await createIndexer({
+  harness: {
+    httpUrl: "https://test-rpc-kujira.mintthemoon.xyz",
+    indexers: [new BasicIndexer()],
+    retrier: retrier,
+    type: EndpointType.WEBSOCKET,
+    wsUrl: "wss://test-rpc-kujira.mintthemoon.xyz/websocket",
+  },
+  minLogLevel: "trace",
+});
+
+const backfillerWithCustomRetrier = await createBackfiller({
+  harness: {
+    indexer: new BasicIndexer(),
+    retrier: expRetrier,
+    httpUrl: "https://test-rpc-kujira.mintthemoon.xyz",
+  },
+  backfillSetup: {
+    backfillOrder: BackfillOrder.ASCENDING,
+  },
+});
+```
+
+An error retrier can also be created, whcih automatically retries when an error is thrown.
+
+```typescript
+import { createErrorRetrier } from "tendermint-indexer";
+
+const errorRetrier = createErrorRetrier(retrier);
+```
+
+## Add a Persister
+
+A persister is a single source of truth on which blocks have been indexed. Real-time indexers do not reqire a persister, but backfilling indexers do require persisters to know which blocks are unprocessed.
+
+To setup an indexer with a persister:
+
+```typescript
+import { PersistantIndexer, Persister } from "tendermint-indexer";
+
+class BasicPersister implements Persister {
+  public async getUnprocessedBlockRanges(): Promise<BlockRange[]> {
+    // Implement logic for fetching unprocessed block ranges from a database
+    return [];
+  }
+
+  public async persistBlock(blockHeight: number): Promise<void> {
+    // Store persisted block heights in a database
+  }
+}
+
+class BasicIndexer implements PersistantIndexer {
+  persister: BasicPersister;
+
+  private async indexer({
+    blockHeight,
+    eventAttributes,
+    eventType,
+  }: EventIndexer) {
+    // Replace with your own indexing logic!
+    console.log(blockHeight);
+    console.log(eventAttributes);
+    console.log(eventType);
+  }
+
+  public subscriptions(): Subscription[] {
+    return [
+      {
+        indexer: this.indexer.bind(this),
+        type: IndexerDataType.EVENT,
+      },
+    ];
+  }
+
+  public async destroy(): Promise<void> {}
+}
+```
+
+A SQL persister is available and requires a function that runs raw SQL queries in a SQL database (PostgreSQL, MySQL, etc.). The SQL persister creates a table for storing inclusive ranges of processed blocks' heights.
+
+```typescript
+import {
+  SQLPersister,
+  DEFAULT_RETRIER,
+  CometHttpClient,
+} from "tendermint-indexer";
+
+const httpClient = await CometHttpClient.create(
+  "https://test-rpc-kujira.mintthemoon.xyz",
+  DEFAULT_RETRIER
+);
+
+const sqlPersister = new SQLPersister(
+  async (query: string) => {
+    // Implement logic for running raw SQL queries in a SQL database
+    return [];
+  },
+  "blockHeightTableName",
+  httpClient
+);
+// Create the SQL table if it already doesn't exist
+await persister.setup();
+```
 
 ## How does the Indexer work?
 
@@ -154,3 +239,187 @@ The backfiller will process blocks in descending order from largest block height
 This guarantees that `tendermint-indexer` achieves **exactly-once semantics**, can **recover** from network failure, and delivers block data in **increasing order** of block height.
 
 The backfiller works in a similar way, but relies on an `Indexer`'s `Persister` to index and record the unprocessed blocks.
+
+## More Indexer Examples
+
+Below are some more examples on more complex indexers.
+
+```typescript
+import {
+  Indexer,
+  type Subscription,
+  IndexerDataType,
+  type EventIndexer,
+  type TxIndexer,
+  type BlockIndexer,
+} from "tendermint-indexer";
+
+class ComplexIndexer implements Indexer {
+  private async eventIndexer({
+    blockHeight,
+    eventAttributes,
+    eventType,
+  }: EventIndexer) {
+    console.log(blockHeight);
+    console.log(eventAttributes);
+    console.log(eventType);
+  }
+
+  private async txIndexer({ tx, blockHeight }: TxIndexer) {
+    console.log(tx);
+    console.log(blockHeight);
+  }
+
+  private async blockIndexeer({
+    block,
+    blockHeight,
+    blockResults,
+  }: BlockIndexer) {
+    console.log(block);
+    console.log(blockHeight);
+    console.log(blockResults);
+  }
+
+  public subscriptions(): Subscription[] {
+    // Indexers will be called in sequential order
+    return [
+      {
+        indexer: this.eventIndexer.bind(this),
+        type: IndexerDataType.EVENT,
+        filter: {
+          eventType: {
+            // Index an event if its type is "transfer"
+            matches: ["transfer"],
+            //  Index an event if its type contains "a" or "b"
+            contains: ["a", "b"],
+          },
+        },
+      },
+      {
+        indexer: this.txIndexer.bind(this),
+        type: IndexerDataType.TX,
+      },
+      {
+        indexer: this.blockIndexer.bind(this),
+        type: IndexerDataType.BLOCK,
+      },
+    ];
+  }
+
+  public async destroy(): Promise<void> {}
+}
+```
+
+## More Backfiller Examples
+
+Below are some more examples on more complex backfillers.
+
+### Backfill unprocessed blocks in a concurrent order
+
+```typescript
+import { CreateBackfillerParams } from "tendermint-indexer";
+
+const concurrentBackfill: CreateBackfillerParams = {
+  harness: {
+    indexer: singleIndexer,
+    retrier,
+    httpUrl: "https://test-rpc-kujira.mintthemoon.xyz",
+  },
+  backfillSetup: {
+    backfillOrder: BackfillOrder.CONCURRENT,
+    numProcesses: 4,
+  },
+};
+```
+
+### Ascending backfill to specific block or timestamp
+
+```typescript
+import { CreateBackfillerParams, CometHttpClient } from "tendermint-indexer";
+
+function range(start: number, end: number, step = 1) {
+  return Array(Math.floor((end - start) / step) + 1)
+    .fill()
+    .map((_, idx) => start + idx * step);
+}
+
+function blockHeightAtTime(date: Date): Promise<number> {
+  const url = `https://api.kujira.app/api/block?before=${date.toISOString()}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch block height: ${res.statusText}`);
+  }
+  const data = await res.json();
+  return data.height;
+}
+
+const httpUrl = "https://test-rpc-kujira.mintthemoon.xyz";
+const httpClient = await CometHttpClient.create(httpUrl, DEFAULT_RETRIER);
+const { latestBlockHeight } = await httpClient.getBlockHeights();
+
+const startBlockHeight = blockHeightAtTime(new Date("11/01/2023"));
+const blockHeightsToProcess = range(startBlockHeight, latestBlockHeight);
+
+const specificBlockBackfill: CreateBackfillerParams = {
+  harness: {
+    indexer: singleIndexer,
+    retrier,
+    httpUrl,
+  },
+  backfillSetup: {
+    backfillOrder: BackfillOrder.SPECIFIC,
+    blockHeightsToProcess,
+    shouldPersist: true,
+  },
+};
+```
+
+### Descending backfill to specific block or timestamp
+
+```typescript
+// Same logic as above, but reverse blockHeightsToProcess
+const specificBlockBackfill: CreateBackfillerParams = {
+  harness: {
+    indexer: singleIndexer,
+    retrier,
+    httpUrl,
+  },
+  backfillSetup: {
+    backfillOrder: BackfillOrder.SPECIFIC,
+    blockHeightsToProcess: blockHeightsToProcess.reverse(),
+    shouldPersist: true,
+  },
+};
+```
+
+### Backfill using a specific range
+
+```typescript
+// Index every 10,000 blocks
+import { CreateBackfillerParams, CometHttpClient } from "tendermint-indexer";
+
+const httpUrl = "https://test-rpc-kujira.mintthemoon.xyz";
+const httpClient = await CometHttpClient.create(httpUrl, DEFAULT_RETRIER);
+const { earliestBlockHeight, latestBlockHeight } =
+  await httpClient.getBlockHeights();
+
+const startBlockHeight = blockHeightAtTime(new Date("11/01/2023"));
+const blockHeightsToProcess = range(
+  earliestBlockHeight,
+  latestBlockHeight,
+  10000
+);
+
+const specificBlockBackfill: CreateBackfillerParams = {
+  harness: {
+    indexer: singleIndexer,
+    retrier,
+    httpUrl,
+  },
+  backfillSetup: {
+    backfillOrder: BackfillOrder.SPECIFIC,
+    blockHeightsToProcess,
+    shouldPersist: false,
+  },
+};
+```

--- a/src/createBackfiller.ts
+++ b/src/createBackfiller.ts
@@ -5,6 +5,7 @@ import backfillBlockRange from "./utils/backfillBlockRange";
 import { splitRangeEvenly, splitRangesBySize } from "./utils/splitRange";
 import { backfillBlock } from "./utils/backfillBlock";
 import logger, { setMinLogLevel } from "./modules/logger";
+import { DEFAULT_RETRIER } from './modules/retry';
 
 // Minimum number of blocks that be processed by a single process when parallel backfilling
 const MIN_BLOCKS_PER_RANGE = 100;
@@ -24,7 +25,7 @@ export default async function createBackfiller({
 
   const httpClient = await CometHttpClient.create(
     harness.httpUrl,
-    harness.retrier
+    harness.retrier || DEFAULT_RETRIER
   );
 
   async function start() {

--- a/src/createBackfiller.ts
+++ b/src/createBackfiller.ts
@@ -37,6 +37,7 @@ export default async function createBackfiller({
     switch (backfillOrder) {
       case BackfillOrder.ASCENDING:
       case BackfillOrder.DESCENDING:
+
         // Process blocks not seen by the backfiller
         let unprocessedBlockRanges =
           await harness.indexer.persister.getUnprocessedBlockRanges();

--- a/src/createIndexer.ts
+++ b/src/createIndexer.ts
@@ -3,7 +3,7 @@ import {
   isConnectionEvent,
   type NewBlockEvent,
 } from "./types/Events";
-import type { CreateIndexerFunction } from "./types/CreateIndexerFunction";
+import type { CreateIndexerParams } from "./types/CreateIndexerParams";
 import { createSubscriptionClient } from "./utils/createSubscriptionClient";
 import type { AddEventFunction } from "./types/AddEventFunction";
 import processEventsBySubscription from "./utils/processEventsBySubscription";
@@ -24,7 +24,7 @@ const DESTROY_DELAY_MS = 3000;
 export default async function createIndexer({
   harness,
   minLogLevel = "trace",
-}: CreateIndexerFunction) {
+}: CreateIndexerParams) {
   setMinLogLevel(minLogLevel);
   let prevBlockHeight = 0;
   const tmEventQueue: (NewBlockEvent | ConnectionEvent)[] = [];

--- a/src/createIndexer.ts
+++ b/src/createIndexer.ts
@@ -10,6 +10,7 @@ import processEventsBySubscription from "./utils/processEventsBySubscription";
 import logger, { setMinLogLevel } from "./modules/logger";
 import { CometHttpClient } from "./clients/cometHttpClient";
 import { sleep } from "./utils/sleep";
+import { DEFAULT_RETRIER } from "./modules/retry";
 
 // Delay between each time the indexer queue is processed 
 const PROCESS_QUEUE_EVERY_MS = 100;
@@ -40,7 +41,7 @@ export default async function createIndexer({
 
   const httpClient = await CometHttpClient.create(
     harness.httpUrl,
-    harness.retrier,
+    harness.retrier || DEFAULT_RETRIER,
   );
 
   async function processTmEventQueue() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {
   type TxIndexer,
   type EventIndexer,
 } from "./types/Indexer";
-import { Indexer } from "./modules/indexer";
+import { Indexer, PersistantIndexer } from './modules/indexer';
 import { Persister } from "./modules/persister";
 import type { BlockRange } from "./types/BlockRange";
 import type { IndexerHarness, BackfillHarness } from "./types/Harness";
@@ -34,6 +34,7 @@ export {
   createRetrier,
   EndpointType,
   Indexer,
+  PersistantIndexer,
   IndexerDataType,
   Persister,
   SQLPersister,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,17 @@ import createBackfiller from "./createBackfiller";
 import createIndexer from "./createIndexer";
 import { EndpointType } from "./types/EndpointType";
 import { BackfillOrder } from "./types/BackfillOrder";
-import type { BackfillSetup } from "./types/CreateBackfillerFunction";
+import type {
+  BackfillSetup,
+  CreateBackfillerParams,
+} from "./types/CreateBackfillerParams";
 import {
   createExpBackoffRetrier,
   createErrorRetrier,
   type ErrorRetrier,
   type Retrier,
   createRetrier,
+  DEFAULT_RETRIER,
 } from "./modules/retry";
 import type { Subscription } from "./types/Subscription";
 import {
@@ -18,11 +22,12 @@ import {
   type TxIndexer,
   type EventIndexer,
 } from "./types/Indexer";
-import { Indexer, PersistantIndexer } from './modules/indexer';
+import { Indexer, PersistantIndexer } from "./modules/indexer";
 import { Persister } from "./modules/persister";
 import type { BlockRange } from "./types/BlockRange";
 import type { IndexerHarness, BackfillHarness } from "./types/Harness";
-import { SQLPersister } from './modules/sqlPersister';
+import { SQLPersister } from "./modules/sqlPersister";
+import { CreateIndexerParams } from "./types/CreateIndexerParams";
 
 export {
   BackfillOrder,
@@ -32,16 +37,19 @@ export {
   createExpBackoffRetrier,
   createIndexer,
   createRetrier,
+  DEFAULT_RETRIER,
   EndpointType,
   Indexer,
-  PersistantIndexer,
   IndexerDataType,
+  PersistantIndexer,
   Persister,
   SQLPersister,
   type BackfillHarness,
   type BackfillSetup,
   type BlockIndexer,
   type BlockRange,
+  type CreateBackfillerParams,
+  type CreateIndexerParams,
   type ErrorRetrier,
   type EventIndexer,
   type IndexerHarness,

--- a/src/modules/indexer.ts
+++ b/src/modules/indexer.ts
@@ -1,14 +1,14 @@
 import type { Subscription } from "../types/Subscription";
 import type { Persister } from "./persister";
 
-/** 
+/**
  * An interface for a general indexer
-*/ 
+ */
 export abstract class Indexer {
   /**
-   * Persister that retries on indexer failures, including network failures
+   * Optional persister that retries on indexer failures, including network failures
    */
-  abstract persister: Persister;
+   abstract persister?: Persister;
   /**
    * List of event, block, or transaction subscriptions
    */
@@ -17,4 +17,11 @@ export abstract class Indexer {
    * Callback for destroying the indexer
    */
   public abstract destroy(): Promise<void>;
+}
+
+export abstract class PersistantIndexer extends Indexer {
+  /**
+   * Required persister that retries on indexer failures, including network failures
+   */
+   abstract persister: Persister;
 }

--- a/src/modules/retry.ts
+++ b/src/modules/retry.ts
@@ -169,3 +169,10 @@ export const createExpBackoffRetrier = (
     )
   );
 };
+
+export const DEFAULT_RETRIER = createExpBackoffRetrier({
+  initialInterval: 1000,
+  expFactor: 2,
+  maxInterval: 60000,
+  jitter: 1000,
+});

--- a/src/types/AddEventFunction.ts
+++ b/src/types/AddEventFunction.ts
@@ -1,3 +1,6 @@
 import type { ConnectionEvent, NewBlockEvent } from "./Events";
 
+/**
+ * Type for the handler that adds new blocks or new connection events to a processing queue
+ */
 export type AddEventFunction = (event: NewBlockEvent | ConnectionEvent) => void;

--- a/src/types/BackfillOrder.ts
+++ b/src/types/BackfillOrder.ts
@@ -4,8 +4,8 @@ export const BackfillOrder = {
   // Processed all unprocessed blocks in a one-by-one order
   ASCENDING: "ASCENDING",
   DESCENDING: "DESCENDING",
-  // Process all unprocessed blocks in a parallel order
-  PARALLEL: "PARALLEL",
+  // Process all unprocessed blocks in a concurrent order
+  CONCURRENT: "CONCURRENT",
   // Only processess specified blocks
   SPECIFIC: "SPECIFIC",
 } as const;

--- a/src/types/BlockRange.ts
+++ b/src/types/BlockRange.ts
@@ -1,3 +1,6 @@
+/**
+ * Represents an inclusive range of blocks
+ */
 export type BlockRange = {
   startBlockHeight: number;
   endBlockHeight: number;

--- a/src/types/CreateBackfillerFunction.ts
+++ b/src/types/CreateBackfillerFunction.ts
@@ -8,20 +8,26 @@ import type { LevelWithSilentOrString } from "pino";
 export type CreateBackfillerFunction = {
   backfillSetup:
     | {
+        // Backfill unprocessed blocks in ascending or descending order of block height
         backfillOrder:
           | typeof BackfillOrder.DESCENDING
           | typeof BackfillOrder.ASCENDING;
       }
     | {
+        // Backfill unprocessed blocks  in any order of block height in a parallel manner
         backfillOrder: typeof BackfillOrder.PARALLEL;
         numThreads: number;
       }
     | {
+        // Backfill specified blocks in order of position in blockHeightsToProcess
         backfillOrder: typeof BackfillOrder.SPECIFIC;
         blockHeightsToProcess: number[];
+        // If false, skip persisting each block after indexing
         shouldPersist: boolean;
       };
+  // Structure that maintains a single indexer and relevant network parameters
   harness: BackfillHarness;
+  // Minimum Pino log level for printing info, warning, error, and fatal indexer logs
   minLogLevel?: LevelWithSilentOrString;
 };
 

--- a/src/types/CreateBackfillerParams.ts
+++ b/src/types/CreateBackfillerParams.ts
@@ -5,7 +5,7 @@ import type { LevelWithSilentOrString } from "pino";
 /**
  * Parameters required to setup a backfiller that feeds into a PostgreSQL database.
  */
-export type CreateBackfillerFunction = {
+export type CreateBackfillerParams = {
   backfillSetup:
     | {
         // Backfill unprocessed blocks in ascending or descending order of block height
@@ -14,9 +14,10 @@ export type CreateBackfillerFunction = {
           | typeof BackfillOrder.ASCENDING;
       }
     | {
-        // Backfill unprocessed blocks  in any order of block height in a parallel manner
-        backfillOrder: typeof BackfillOrder.PARALLEL;
-        numThreads: number;
+        // Backfill unprocessed blocks in any order of block height in a concurrent manner
+        backfillOrder: typeof BackfillOrder.CONCURRENT;
+        // Number of concurrent processes that are backfilling
+        numProcesses: number;
       }
     | {
         // Backfill specified blocks in order of position in blockHeightsToProcess
@@ -31,4 +32,4 @@ export type CreateBackfillerFunction = {
   minLogLevel?: LevelWithSilentOrString;
 };
 
-export type BackfillSetup = CreateBackfillerFunction["backfillSetup"];
+export type BackfillSetup = CreateBackfillerParams["backfillSetup"];

--- a/src/types/CreateIndexerFunction.ts
+++ b/src/types/CreateIndexerFunction.ts
@@ -5,6 +5,8 @@ import type { IndexerHarness } from "./Harness";
  * Parameters required to setup an indexer that feeds into a PostgreSQL database.
  */
 export type CreateIndexerFunction = {
+  // Structure that maintains one or many indexers and relevant network parameters
   harness: IndexerHarness;
+  // Minimum Pino log level for printing info, warning, error, and fatal indexer logs
   minLogLevel?: LevelWithSilentOrString;
 };

--- a/src/types/CreateIndexerParams.ts
+++ b/src/types/CreateIndexerParams.ts
@@ -4,7 +4,7 @@ import type { IndexerHarness } from "./Harness";
 /**
  * Parameters required to setup an indexer that feeds into a PostgreSQL database.
  */
-export type CreateIndexerFunction = {
+export type CreateIndexerParams = {
   // Structure that maintains one or many indexers and relevant network parameters
   harness: IndexerHarness;
   // Minimum Pino log level for printing info, warning, error, and fatal indexer logs

--- a/src/types/Harness.ts
+++ b/src/types/Harness.ts
@@ -1,4 +1,4 @@
-import type { Indexer } from "../modules/indexer";
+import type { Indexer, PersistantIndexer } from "../modules/indexer";
 import type { Retrier } from "../modules/retry";
 import type { EndpointType } from "./EndpointType";
 
@@ -8,7 +8,10 @@ import type { EndpointType } from "./EndpointType";
  */
 export type IndexerHarness = {
   indexers: Indexer[];
-  // Retries any failed network calls and connection attempts
+  /** Retries any failed network calls and connection attempts. 
+   * If null, an exponential backoff retrier that switches to linear backoff at a 60 seconds
+   * threshold will be used.
+  */
   retrier?: Retrier;
 } & (
   | {
@@ -27,8 +30,14 @@ export type IndexerHarness = {
  * No WebSocket or HTTP polling connection necessary.
  */
 export type BackfillHarness = {
-  indexer: Indexer;
-    // Retries any failed network calls and connection attempts
+  /** Only a single indexer is allowed per backfill since different indexers may have different
+   * ranges of unprocessed blocks.
+   */
+  indexer: PersistantIndexer;
+  /** Retries any failed network calls and connection attempts. 
+   * If null, an exponential backoff retrier that switches to linear backoff at a 60 seconds
+   * threshold will be used.
+  */
   retrier?: Retrier;
   httpUrl: `http://${string}` | `https://${string}`;
 };

--- a/src/types/Harness.ts
+++ b/src/types/Harness.ts
@@ -8,7 +8,8 @@ import type { EndpointType } from "./EndpointType";
  */
 export type IndexerHarness = {
   indexers: Indexer[];
-  retrier: Retrier;
+  // Retries any failed network calls and connection attempts
+  retrier?: Retrier;
 } & (
   | {
       type: typeof EndpointType.WEBSOCKET;
@@ -27,6 +28,7 @@ export type IndexerHarness = {
  */
 export type BackfillHarness = {
   indexer: Indexer;
-  retrier: Retrier;
+    // Retries any failed network calls and connection attempts
+  retrier?: Retrier;
   httpUrl: `http://${string}` | `https://${string}`;
 };

--- a/src/types/Indexer.ts
+++ b/src/types/Indexer.ts
@@ -9,7 +9,9 @@ import type { ValuesUnion } from "./ValuesUnion";
  * Data passed into an Event indexer: event type, event attributes, and block height.
  */
 export type EventIndexer = {
+  // Attribute data associted with the indexed event
   eventAttributes: Record<string, string>;
+  // The type of the indexed event
   eventType: string;
   blockHeight: number;
 };
@@ -18,7 +20,9 @@ export type EventIndexer = {
  * Data passed into an Block indexer: block header, block results, and block height.
  */
 export type BlockIndexer = {
+  // Contains header, transactions, last commit, and evidence
   block: Block;
+  // Contains transactions, validator updates, and consensus updates
   blockResults: BlockResultsResponse;
   blockHeight: number;
 };
@@ -27,6 +31,7 @@ export type BlockIndexer = {
  * Data passed into an Transaction (Tx) indexer: list of transactions and block height.
  */
 export type TxIndexer = {
+  // Contains events ad gas for each transaction in the indexed block
   tx: readonly TxData[];
   blockHeight: number;
 };

--- a/src/types/Subscription.ts
+++ b/src/types/Subscription.ts
@@ -10,7 +10,9 @@ import type {
  */
 export type EventFilter = {
   eventType: {
+    // Return true if there is at least an event type in matches that is an exact match
     matches?: string[];
+    // Return true if there is at least one event type in contains that appears as a substring  
     contains?: string[];
   };
 };
@@ -35,6 +37,7 @@ export type TxSubscription = {
  * Subscription for an event
  */
 export type EventSubscription = {
+  // If filter is not specified, all events are indexed.
   filter?: EventFilter;
   indexer: (arg: EventIndexer) => void;
   type: typeof IndexerDataType.EVENT;

--- a/src/utils/createSubscriptionClient.ts
+++ b/src/utils/createSubscriptionClient.ts
@@ -2,6 +2,7 @@ import { CometWsClient, CometHttpPollClient } from "../clients";
 import { EndpointType } from "../types/EndpointType";
 import type { IndexerHarness } from "../types/Harness";
 import type { AddEventFunction } from "../types/AddEventFunction";
+import { DEFAULT_RETRIER } from "../modules/retry";
 
 /**
  * Creates and returns a WebSocket or HTTP Polling Subscription client
@@ -17,14 +18,14 @@ export async function createSubscriptionClient({
     case EndpointType.WEBSOCKET:
       const wsClient = await CometWsClient.create(
         harness.wsUrl,
-        harness.retrier,
+        harness.retrier || DEFAULT_RETRIER,
         addEvent,
       );
       return wsClient;
     case EndpointType.HTTP_POLL:
       const httpClient = await CometHttpPollClient.create(
         harness.httpUrl,
-        harness.retrier,
+        harness.retrier || DEFAULT_RETRIER,
         addEvent,
       );
       return httpClient;

--- a/src/utils/processEventsBySubscription.ts
+++ b/src/utils/processEventsBySubscription.ts
@@ -50,7 +50,7 @@ export default async function processEventsBySubscription({
       }
     }
     if (shouldPersist) {
-      await indexer.persister.persistBlock(newBlockEvent.blockHeight);
+      await indexer.persister?.persistBlock(newBlockEvent.blockHeight);
     }
   }
 }

--- a/tests/backfiller.test.ts
+++ b/tests/backfiller.test.ts
@@ -1,5 +1,5 @@
 import { TEST_ARCHIVE_HTTP_URL } from "./consts";
-import { BackfillSetup } from "../dist/src/types/CreateBackfillerFunction";
+import { BackfillSetup } from "../src";
 import { SQLPersister } from "../src/modules/sqlPersister";
 import {
   createBackfiller,
@@ -177,10 +177,10 @@ test("Succeed in descending backfill", async () => {
   ]);
 }, 15000);
 
-test("Succeed in parallel backfill", async () => {
+test("Succeed in concurrent backfill", async () => {
   const blockHeights = await testBackfiller({
-    backfillOrder: "PARALLEL",
-    numThreads: 3,
+    backfillOrder: "CONCURRENT",
+    numProcesses: 3,
   });
   expect(blockHeights).toEqual([
     {


### PR DESCRIPTION
- Make the retrier and persister optional to simplify indexer setup.
- Add documentation to create indexer and create backfiller types.
- Add more examples for custom backfillers to the README.