### PR TITLE
Speed up concurrent backfill

### DIFF
--- a/src/clients/cometHttpClient.ts
+++ b/src/clients/cometHttpClient.ts
@@ -1,9 +1,16 @@
-import { HttpClient, Tendermint37Client } from "@cosmjs/tendermint-rpc";
+import {
+  HttpBatchClient,
+  HttpClient,
+  Tendermint37Client,
+} from "@cosmjs/tendermint-rpc";
 import flattenEvent from "../utils/flattenEvent";
 import type { ErrorRetrier, Retrier } from "../modules/retry";
 import { createErrorRetrier } from "../modules/retry";
 import logger from "../modules/logger";
 import type { BlockData } from "../types/BlockData";
+
+const BATCH_DISPATCH_INTERVAL = 200;
+const BATCH_SIZE_LIMIT = 20;
 
 /**
  * Sets up a CometBFT HTTP connection to query block information
@@ -25,10 +32,21 @@ export class CometHttpClient {
    * Create a new CometHTTPClient
    * @param endpoint RPC HTTP endpoint
    * @param retrier Error retrier that wraps around HTTP RPC calls
+   * @param shouldBatchRequests If true, HTTP requests will be batched
    * @returns CometHTTPClient
    */
-  static async create(endpoint: string, retrier: Retrier) {
-    const rpcClient = new HttpClient(endpoint);
+  static async create(
+    endpoint: string,
+    retrier: Retrier,
+    shouldBatchRequests = false
+  ) {
+    const rpcClient = shouldBatchRequests
+      ? new HttpBatchClient(endpoint, {
+          dispatchInterval: BATCH_DISPATCH_INTERVAL,
+          batchSizeLimit: BATCH_SIZE_LIMIT,
+        })
+      : new HttpClient(endpoint);
+
     const tmClient = await Tendermint37Client.create(rpcClient);
     return new CometHttpClient(tmClient, retrier);
   }

--- a/src/clients/cometHttpClient.ts
+++ b/src/clients/cometHttpClient.ts
@@ -9,6 +9,10 @@ import { createErrorRetrier } from "../modules/retry";
 import logger from "../modules/logger";
 import type { BlockData } from "../types/BlockData";
 
+/**
+ * Parameters found to work well with larger backfills, but may need further
+ * benchmarking/tweaking.
+ */
 const BATCH_DISPATCH_INTERVAL = 200;
 const BATCH_SIZE_LIMIT = 20;
 

--- a/src/createBackfiller.ts
+++ b/src/createBackfiller.ts
@@ -76,7 +76,6 @@ export default async function createBackfiller({
             numSplit: numProcesses,
           });
 
-          // Since this is I/O intensive, favor async/await as opposed to multithreading/multiprocessing
           await Promise.all(
             evenUnprocessedBlockRanges.map(
               ({ startBlockHeight, endBlockHeight }) =>

--- a/src/createBackfiller.ts
+++ b/src/createBackfiller.ts
@@ -20,7 +20,9 @@ export default async function createBackfiller({
 
   const httpClient = await CometHttpClient.create(
     harness.httpUrl,
-    harness.retrier || DEFAULT_RETRIER
+    harness.retrier || DEFAULT_RETRIER,
+    // Batch concurrent http requests for block data
+    backfillSetup.backfillOrder === BackfillOrder.CONCURRENT_SPECIFIC
   );
 
   async function start() {

--- a/src/types/BackfillOrder.ts
+++ b/src/types/BackfillOrder.ts
@@ -6,10 +6,10 @@ export const BackfillOrder = {
   DESCENDING: "DESCENDING",
   // Process all unprocessed block ranges in a concurrent order
   CONCURRENT: "CONCURRENT",
-  // Only processess specified blocks
-  SPECIFIC: "SPECIFIC",
   // Process specified blocks in a concurrent order
   CONCURRENT_SPECIFIC: "CONCURRENT_SPECIFIC",
+  // Only processess specified blocks
+  SPECIFIC: "SPECIFIC",
 } as const;
 
 export type BackfillOrder = ValuesUnion<typeof BackfillOrder>;

--- a/src/types/BackfillOrder.ts
+++ b/src/types/BackfillOrder.ts
@@ -1,13 +1,15 @@
 import type { ValuesUnion } from "./ValuesUnion";
 
 export const BackfillOrder = {
-  // Processed all unprocessed blocks in a one-by-one order
+  // Processed all unprocessed block ranges in a one-by-one order
   ASCENDING: "ASCENDING",
   DESCENDING: "DESCENDING",
-  // Process all unprocessed blocks in a concurrent order
+  // Process all unprocessed block ranges in a concurrent order
   CONCURRENT: "CONCURRENT",
   // Only processess specified blocks
   SPECIFIC: "SPECIFIC",
+  // Process specified blocks in a concurrent order
+  CONCURRENT_SPECIFIC: "CONCURRENT_SPECIFIC",
 } as const;
 
 export type BackfillOrder = ValuesUnion<typeof BackfillOrder>;

--- a/src/types/CreateBackfillerParams.ts
+++ b/src/types/CreateBackfillerParams.ts
@@ -22,8 +22,8 @@ export type CreateBackfillerParams = {
     | {
         // Backfill specified blocks in order of position in blockHeightsToProcess
         backfillOrder:
-          | typeof BackfillOrder.SPECIFIC
-          | typeof BackfillOrder.CONCURRENT_SPECIFIC;
+          | typeof BackfillOrder.CONCURRENT_SPECIFIC
+          | typeof BackfillOrder.SPECIFIC;
         blockHeightsToProcess: number[];
         // If false, skip persisting each block after indexing
         shouldPersist: boolean;

--- a/src/types/CreateBackfillerParams.ts
+++ b/src/types/CreateBackfillerParams.ts
@@ -14,14 +14,16 @@ export type CreateBackfillerParams = {
           | typeof BackfillOrder.ASCENDING;
       }
     | {
-        // Backfill unprocessed blocks in any order of block height in a concurrent manner
+        // Backfill unprocessed blocks in a concurrent manner
         backfillOrder: typeof BackfillOrder.CONCURRENT;
         // Number of concurrent processes that are backfilling
         numProcesses: number;
       }
     | {
         // Backfill specified blocks in order of position in blockHeightsToProcess
-        backfillOrder: typeof BackfillOrder.SPECIFIC;
+        backfillOrder:
+          | typeof BackfillOrder.SPECIFIC
+          | typeof BackfillOrder.CONCURRENT_SPECIFIC;
         blockHeightsToProcess: number[];
         // If false, skip persisting each block after indexing
         shouldPersist: boolean;

--- a/src/utils/splitRange.ts
+++ b/src/utils/splitRange.ts
@@ -5,11 +5,9 @@ import type { BlockRange } from "../types/BlockRange";
  * with a minimum size
  */
 export function splitRangeEvenly({
-  minBlocksPerRange,
   numSplit,
   blockRange,
 }: {
-  minBlocksPerRange: number;
   numSplit: number;
   blockRange: BlockRange;
 }): BlockRange[] {
@@ -17,7 +15,9 @@ export function splitRangeEvenly({
   const { startBlockHeight, endBlockHeight } = blockRange;
 
   const numBlocksInRange = endBlockHeight - startBlockHeight + 1;
-  if (numBlocksInRange <= minBlocksPerRange || numBlocksInRange < numSplit) {
+
+  // Ensure that each split gets at least one block
+  if (numBlocksInRange < numSplit) {
     return [
       {
         startBlockHeight,
@@ -41,30 +41,4 @@ export function splitRangeEvenly({
   }
 
   return evenblockRanges;
-}
-
-/**
- * Splits block ranges into a specific number of contiguous block ranges
- * with a minimum size
- */
-export function splitRangesEvenly({
-  minBlocksPerRange,
-  numSplit,
-  blockRanges,
-}: {
-  minBlocksPerRange: number;
-  numSplit: number;
-  blockRanges: BlockRange[];
-}) {
-  return blockRanges.reduce(
-    (prevRanges: BlockRange[], currRange) =>
-      prevRanges.concat(
-        splitRangeEvenly({
-          blockRange: currRange,
-          numSplit,
-          minBlocksPerRange,
-        })
-      ),
-    []
-  );
 }

--- a/src/utils/splitRange.ts
+++ b/src/utils/splitRange.ts
@@ -1,68 +1,6 @@
 import type { BlockRange } from "../types/BlockRange";
 
 /**
- * Splits a given block range into smaller, contiguous block ranges
- * of a given size
- */
-function splitRangeBySize({
-  blockRange,
-  size,
-}: {
-  blockRange: BlockRange;
-  size: number;
-}): BlockRange[] {
-  const { startBlockHeight, endBlockHeight } = blockRange;
-  const numBlocksInRange = endBlockHeight - startBlockHeight + 1;
-
-  if (numBlocksInRange <= size) {
-    return [{ startBlockHeight, endBlockHeight }];
-  }
-
-  const blockRanges: BlockRange[] = [];
-
-  const numFullRanges = Math.floor(numBlocksInRange / size);
-
-  for (let idx = 0; idx < numFullRanges; idx++) {
-    blockRanges.push({
-      startBlockHeight: startBlockHeight + size * idx,
-      endBlockHeight: startBlockHeight + size * (idx + 1) - 1,
-    });
-  }
-
-  if (numBlocksInRange % size != 0) {
-    blockRanges.push({
-      startBlockHeight: startBlockHeight + size * numFullRanges,
-      endBlockHeight,
-    });
-  }
-
-  return blockRanges;
-}
-
-/**
- * Splits given block ranges into smaller, contiguous block ranges
- * of a given size
- */
-export function splitRangesBySize({
-  blockRanges,
-  size,
-}: {
-  blockRanges: BlockRange[];
-  size: number;
-}): BlockRange[] {
-  return blockRanges.reduce(
-    (prevRanges: BlockRange[], currRange) =>
-      prevRanges.concat(
-        splitRangeBySize({
-          blockRange: currRange,
-          size,
-        })
-      ),
-    []
-  );
-}
-
-/**
  * Splits a block range into a specific number of contiguous block ranges
  * with a minimum size
  */

--- a/tests/backfiller.test.ts
+++ b/tests/backfiller.test.ts
@@ -142,6 +142,14 @@ test("Succeed in concurrent backfill", async () => {
   expect(blockHeights).toEqual([
     {
       startBlockHeight: 12000001,
+      endBlockHeight: 12000004,
+    },
+    {
+      startBlockHeight: 12000005,
+      endBlockHeight: 12000007,
+    },
+    {
+      startBlockHeight: 12000008,
       endBlockHeight: 12000010,
     },
   ]);
@@ -161,6 +169,40 @@ test("Succeed in specific backfill", async () => {
     {
       startBlockHeight: 12000003,
       endBlockHeight: 12000003,
+    },
+    {
+      startBlockHeight: 12000009,
+      endBlockHeight: 12000009,
+    },
+  ]);
+}, 15000);
+
+test("Succeed in concurrent specific backfill", async () => {
+  const blockHeights = await testBackfiller({
+    backfillOrder: "CONCURRENT_SPECIFIC",
+    blockHeightsToProcess: [12000001, 12000009, 12000003, 12000005, 11000003, 12000007],
+    shouldPersist: true,
+  });
+  expect(blockHeights).toEqual([
+    {
+      startBlockHeight: 11000003,
+      endBlockHeight: 11000003,
+    },
+    {
+      startBlockHeight: 12000001,
+      endBlockHeight: 12000001,
+    },
+    {
+      startBlockHeight: 12000003,
+      endBlockHeight: 12000003,
+    },
+    {
+      startBlockHeight: 12000005,
+      endBlockHeight: 12000005,
+    },
+    {
+      startBlockHeight: 12000007,
+      endBlockHeight: 12000007,
     },
     {
       startBlockHeight: 12000009,

--- a/tests/splitRange.test.ts
+++ b/tests/splitRange.test.ts
@@ -1,30 +1,20 @@
-import { splitRangesEvenly } from "../src/utils/splitRange";
+import { splitRangeEvenly } from "../src/utils/splitRange";
 
 test("Single split", () => {
-  const range = [
-    { startBlockHeight: 4, endBlockHeight: 21 },
-    { startBlockHeight: 25, endBlockHeight: 30 },
-    { startBlockHeight: 31, endBlockHeight: 32 },
-  ];
-  const ans = splitRangesEvenly({
-    minBlocksPerRange: 1,
+  const range = { startBlockHeight: 4, endBlockHeight: 21 };
+  const ans = splitRangeEvenly({
     numSplit: 1,
-    blockRanges: range,
+    blockRange: range,
   });
 
-  expect(ans).toEqual([
-    { startBlockHeight: 4, endBlockHeight: 21 },
-    { startBlockHeight: 25, endBlockHeight: 30 },
-    { startBlockHeight: 31, endBlockHeight: 32 },
-  ]);
+  expect(ans).toEqual([{ startBlockHeight: 4, endBlockHeight: 21 }]);
 });
 
 test("Multiple even split", () => {
-  const range = [{ startBlockHeight: 1, endBlockHeight: 10 }];
-  const ans = splitRangesEvenly({
-    minBlocksPerRange: 1,
+  const range = { startBlockHeight: 1, endBlockHeight: 10 };
+  const ans = splitRangeEvenly({
     numSplit: 5,
-    blockRanges: range,
+    blockRange: range,
   });
 
   expect(ans).toEqual([
@@ -37,11 +27,10 @@ test("Multiple even split", () => {
 });
 
 test("Multiple non even split", () => {
-  const range = [{ startBlockHeight: 1, endBlockHeight: 9 }];
-  const ans = splitRangesEvenly({
-    minBlocksPerRange: 1,
+  const range = { startBlockHeight: 1, endBlockHeight: 9 };
+  const ans = splitRangeEvenly({
     numSplit: 5,
-    blockRanges: range,
+    blockRange: range,
   });
 
   expect(ans).toEqual([
@@ -54,11 +43,10 @@ test("Multiple non even split", () => {
 });
 
 test("Larger multiple non even split", () => {
-  const range = [{ startBlockHeight: 1, endBlockHeight: 12 }];
-  const ans = splitRangesEvenly({
-    minBlocksPerRange: 1,
+  const range = { startBlockHeight: 1, endBlockHeight: 12 };
+  const ans = splitRangeEvenly({
     numSplit: 5,
-    blockRanges: range,
+    blockRange: range,
   });
 
   expect(ans).toEqual([
@@ -71,38 +59,26 @@ test("Larger multiple non even split", () => {
 });
 
 test("Complicated split", () => {
-  const range = [
-    { startBlockHeight: 4, endBlockHeight: 21 },
-    { startBlockHeight: 25, endBlockHeight: 30 },
-    { startBlockHeight: 31, endBlockHeight: 32 },
-  ];
-  const ans = splitRangesEvenly({
-    minBlocksPerRange: 1,
+  const range = { startBlockHeight: 4, endBlockHeight: 21 };
+
+  const ans = splitRangeEvenly({
     numSplit: 2,
-    blockRanges: range,
+    blockRange: range,
   });
 
   expect(ans).toEqual([
     { startBlockHeight: 4, endBlockHeight: 12 },
     { startBlockHeight: 13, endBlockHeight: 21 },
-    { startBlockHeight: 25, endBlockHeight: 27 },
-    { startBlockHeight: 28, endBlockHeight: 30 },
-    { startBlockHeight: 31, endBlockHeight: 31 },
-    { startBlockHeight: 32, endBlockHeight: 32 },
   ]);
 });
 
 test("No split", () => {
-  const range = [
-    { startBlockHeight: 1, endBlockHeight: 3 },
-    { startBlockHeight: 4, endBlockHeight: 6 },
-    { startBlockHeight: 7, endBlockHeight: 12 },
-  ];
-  const ans = splitRangesEvenly({
-    minBlocksPerRange: 6,
-    numSplit: 2,
-    blockRanges: range,
+  const range = { startBlockHeight: 1, endBlockHeight: 3 };
+
+  const ans = splitRangeEvenly({
+    numSplit: 10,
+    blockRange: range,
   });
 
-  expect(ans).toEqual(range);
+  expect(ans).toEqual([range]);
 });

--- a/tests/splitRange.test.ts
+++ b/tests/splitRange.test.ts
@@ -1,4 +1,4 @@
-import { splitRangesEvenly, splitRangesBySize } from "../src/utils/splitRange";
+import { splitRangesEvenly } from "../src/utils/splitRange";
 
 test("Single split", () => {
   const range = [
@@ -53,6 +53,23 @@ test("Multiple non even split", () => {
   ]);
 });
 
+test("Larger multiple non even split", () => {
+  const range = [{ startBlockHeight: 1, endBlockHeight: 12 }];
+  const ans = splitRangesEvenly({
+    minBlocksPerRange: 1,
+    numSplit: 5,
+    blockRanges: range,
+  });
+
+  expect(ans).toEqual([
+    { startBlockHeight: 1, endBlockHeight: 3 },
+    { startBlockHeight: 4, endBlockHeight: 6 },
+    { startBlockHeight: 7, endBlockHeight: 8 },
+    { startBlockHeight: 9, endBlockHeight: 10 },
+    { startBlockHeight: 11, endBlockHeight: 12 },
+  ]);
+});
+
 test("Complicated split", () => {
   const range = [
     { startBlockHeight: 4, endBlockHeight: 21 },
@@ -88,58 +105,4 @@ test("No split", () => {
   });
 
   expect(ans).toEqual(range);
-});
-
-test("Split of size 1", () => {
-  const range = [{ startBlockHeight: 1, endBlockHeight: 5 }];
-  const ans = splitRangesBySize({
-    size: 1,
-    blockRanges: range,
-  });
-
-  expect(ans).toEqual([
-    { startBlockHeight: 1, endBlockHeight: 1 },
-    { startBlockHeight: 2, endBlockHeight: 2 },
-    { startBlockHeight: 3, endBlockHeight: 3 },
-    { startBlockHeight: 4, endBlockHeight: 4 },
-    { startBlockHeight: 5, endBlockHeight: 5 },
-  ]);
-});
-
-test("Split of size 2", () => {
-  const range = [{ startBlockHeight: 1, endBlockHeight: 6 }];
-  const ans = splitRangesBySize({
-    size: 2,
-    blockRanges: range,
-  });
-
-  expect(ans).toEqual([
-    { startBlockHeight: 1, endBlockHeight: 2 },
-    { startBlockHeight: 3, endBlockHeight: 4 },
-    { startBlockHeight: 5, endBlockHeight: 6 },
-  ]);
-});
-
-test("Uneven Split of size 2", () => {
-  const range = [{ startBlockHeight: 1, endBlockHeight: 7 }];
-  const ans = splitRangesBySize({
-    size: 3,
-    blockRanges: range,
-  });
-
-  expect(ans).toEqual([
-    { startBlockHeight: 1, endBlockHeight: 3 },
-    { startBlockHeight: 4, endBlockHeight: 6 },
-    { startBlockHeight: 7, endBlockHeight: 7 },
-  ]);
-});
-
-test("No Split of size 100", () => {
-  const range = [{ startBlockHeight: 1, endBlockHeight: 7 }];
-  const ans = splitRangesBySize({
-    size: 100,
-    blockRanges: range,
-  });
-
-  expect(ans).toEqual([{ startBlockHeight: 1, endBlockHeight: 7 }]);
 });


### PR DESCRIPTION
The `unstake-indexer` and `quark-indexer` use a `BackfillOrder.SPECIFIC` backfill to rebackfill past blockchain data. This is done in a series manner, which means each block is fetched and indexed one by one.

This PR adds `BackfillOrder.CONCURRENT_SPECIFIC` specific backfill to take advantage of await/async and speed up backfills. `BackfillOrder.CONCURRENT` is also sped up with the same technique. 

Notice below how much faster the rebackfills will now be.

## Benchmark
Tested with `unstake-indexer` and a local PostgreSQL database.

20 blocks:
- Non-concurrent: ~13-14 seconds
- Concurrent: ~1-2 seconds

100 blocks:
- Non-concurrent: ~55 seconds
- Concurrent: ~4 seconds