### PR TITLE
Update tests and add better alerting

### DIFF
--- a/src/clients/cometHttpClient.ts
+++ b/src/clients/cometHttpClient.ts
@@ -63,10 +63,14 @@ export class CometHttpClient {
       },
       {
         onFailedAttempt: async (error, attempt) => {
-          logger.warn(`getBlockData() failed attempt ${attempt}: ${error}`);
+          logger.warn(
+            `getBlockData(${height}) failed attempt ${attempt}: ${error}`
+          );
         },
-        onFailedLastAttempt: () => {
-          logger.error("getBlockData(): Max retries exceeded, aborting...");
+        onFailedLastAttempt: (error) => {
+          logger.error(
+            `getBlockData(${height}): Max retries exceeded, aborting...: ${error}`
+          );
         },
       }
     );
@@ -85,10 +89,14 @@ export class CometHttpClient {
       },
       {
         onFailedAttempt: async (error, attempt) => {
-          logger.warn(`getBlockTime() failed attempt ${attempt}: ${error}`);
+          logger.warn(
+            `getBlockTime(${height}) failed attempt ${attempt}: ${error}`
+          );
         },
-        onFailedLastAttempt: () => {
-          logger.error("getBlockTime(): Max retries exceeded, aborting...");
+        onFailedLastAttempt: (error) => {
+          logger.error(
+            `getBlockTime(${height}): Max retries exceeded, aborting...: ${error}`
+          );
         },
       }
     );

--- a/tests/cometHttpPollClient.test.ts
+++ b/tests/cometHttpPollClient.test.ts
@@ -1,7 +1,7 @@
 import { CometHttpPollClient } from "../src/clients/cometHttpPollClient";
 import { createRetrier } from "../src/modules/retry";
 import { sleep } from "../src/utils/sleep";
-import { TEST_ARCHIVE_HTTP_URL } from "./consts";
+import { TEST_HTTP_URL } from "./consts";
 import { isConnectionEvent } from "../src/types/Events";
 
 test("Successfully listen and destroy HTTP Poll Client with proper block height ordering", async () => {
@@ -18,7 +18,7 @@ test("Successfully listen and destroy HTTP Poll Client with proper block height 
   const blockData: number[] = [];
 
   const httpPollClient = await CometHttpPollClient.create(
-    TEST_ARCHIVE_HTTP_URL,
+    TEST_HTTP_URL,
     retrier,
     (event) => {
       if (isConnectionEvent(event)) {
@@ -67,7 +67,7 @@ test("Successfully listen, disconnect, and re-listen HTTP client with proper blo
   const blockData: number[] = [];
 
   const httpPollClient = await CometHttpPollClient.create(
-    TEST_ARCHIVE_HTTP_URL,
+    TEST_HTTP_URL,
     retrier,
     (event) => {
       if (isConnectionEvent(event)) {

--- a/tests/consts.ts
+++ b/tests/consts.ts
@@ -1,4 +1,4 @@
 export const TEST_ARCHIVE_HTTP_URL = "https://kujira-archive.rpc.kjnodes.com/"
 export const TEST_BAD_WS_URL = "ws://test-rpc-kujira.mintthemoon.xyz/websocket"
-export const TEST_WS_URL = "wss://kujira-testnet-rpc.polkachu.com/websocket"
-export const TEST_HTTP_URL = "https://kujira-testnet-rpc.polkachu.com/"
+export const TEST_WS_URL = "wss://rpc-kujira.starsquid.io/websocket"
+export const TEST_HTTP_URL = "https://rpc-kujira.starsquid.io/"

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -64,16 +64,16 @@ async function testIndexer(endpointType: EndpointType, ms: number) {
     public subscriptions(): Subscription[] {
       return [
         {
-          filter: {
-            eventType: {
-              matches: ["transfer"],
-              contains: ["a"],
-            },
-          },
           indexer: this.eventIndexer.bind(this),
           type: IndexerDataType.EVENT,
         },
         {
+          filter: {
+            eventType: {
+              matches: ["transfer"],
+              contains: ["a", "e", "i", "o", "u"],
+            },
+          },
           indexer: this.eventIndexer2.bind(this),
           type: IndexerDataType.EVENT,
         },

--- a/tests/postgresPersister.test.ts
+++ b/tests/postgresPersister.test.ts
@@ -218,7 +218,6 @@ test("getMissingRanges() no overlap with larger range", async () => {
   );
 });
 
-
 test("getMissingRanges() no overlap with one block difference", async () => {
   testGetMissingRanges(
     archiveEarliestBlockHeight,
@@ -252,6 +251,10 @@ test("getMissingRanges() no overlap with one block difference", async () => {
       },
     ]
   );
+});
+
+test("mergeRanges() empty", async () => {
+  testMergeRanges([], [], []);
 });
 
 test("mergeRanges() no overlap", async () => {


### PR DESCRIPTION
<img width="1034" alt="Screenshot 2024-08-01 at 10 41 59 AM" src="https://github.com/user-attachments/assets/b3bb336c-22cc-4cea-9e27-18c705527b3e">

Today, the `unstake-indexer` went down because the WebSocket client pushed a later block before an earlier block. This shouldn't happen since the WebSocket client pushes data in FIFO order. This PR adds better logging and catches to prevent this from happening. It also updates some of the test cases reliant on testnet since testnet is currently down.